### PR TITLE
Remove unnecessary setup step

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,5 @@ export MATPLOTLIBRC=.matplotlib
 # Install python requirements
 pip install -r requirements.txt
 
-# Make sure we have python 3 kernel for jupyter notebook
-ipython3 kernelspec install-self
-
 # Download the raw data
 bash download.sh


### PR DESCRIPTION
I had originally added a line to make sure I had python 3 kernel available when I launch a jupyter notebook (`jupyter notebook`) but it turns out this was just a problem with my original configuration. A python 3 kernel should be available without any extra setup given the current virtualenv.